### PR TITLE
[Work in progress!] Docker configuration for genomics workshop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:17.10
+LABEL author="Daniel Standage"
+LABEL maintainer="daniel.standage@gmail.com"
+
+WORKDIR /datacarpentry/
+COPY ./bashrc /datacarpentry/.bashrc
+
+# Precise versions not necessary for system packages
+RUN apt-get update
+RUN apt-get install -y less perl curl wget tmux nano
+
+# We want precise versions for bioinformatics packages
+RUN apt-get install -y \
+        fastqc=0.11.5+dfsg-6 \
+        trimmomatic=0.36+dfsg-3 \
+        bwa=0.7.15-5 \
+        samtools=1.4.1-1build1 \
+        bcftools=1.4.1-3build1
+
+# Download and store some data sets
+RUN mkdir -p /datacarpentry/.rawdata/
+RUN curl -L https://osf.io/d98sh/?download=1 > /datacarpentry/.rawdata/SRR2584858_1.fastq.gz
+RUN curl -L https://osf.io/ev85t/?download=1 > /datacarpentry/.rawdata/SRR2584858_2.fastq.gz
+RUN curl -L https://osf.io/jqdxf/?download=1 > /datacarpentry/.rawdata/SRR2584859_1.fastq.gz
+RUN curl -L https://osf.io/5y9nu/?download=1 > /datacarpentry/.rawdata/SRR2584859_2.fastq.gz
+RUN curl -L https://osf.io/eaynk/?download=1 > /datacarpentry/.rawdata/SRR2584860_1.fastq.gz
+RUN curl -L https://osf.io/qtng9/?download=1 > /datacarpentry/.rawdata/SRR2584860_2.fastq.gz
+# Make the raw data read-only!!!
+RUN chmod 444 /datacarpentry/.rawdata/SRR*.fastq.gz
+
+# Register and execute the `dcsetup` command for populating the
+# `/datacarpentry/data/` working directory.
+RUN cat /datacarpentry/.bashrc >> ~/.bashrc
+RUN bash -c "source /datacarpentry/.bashrc && dcsetup"
+
+CMD bash

--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,6 @@
+dcsetup()
+{
+    rm -rf /datacarpentry/data/
+    mkdir -p /datacarpentry/data/
+    ln -s /datacarpentry/.rawdata/SRR*.fastq.gz /datacarpentry/data/.
+}


### PR DESCRIPTION
During last week's bug BBQ, several related threads all ran together for me.

- upgrading from `bwa aln` to `bwa mem` in the variant calling section of wrangling-genomics (https://github.com/datacarpentry/wrangling-genomics/issues/111)
- selecting a more recent a data set #42)
- make raw data read-only, hidden; symlink or copy data to a working directory; hide irrelevant details from learners (#43)
- using a single software configuration environment regardless of whether it's deployed on the cloud, on HPC, or on local machines (first discussed in https://github.com/datacarpentry/shell-genomics/issues/49, then migrated to #28)

On Friday (and a bit on Saturday) I prototyped a Docker image with the software required to run most of the genomics modules. Note: I haven't installed R or Rstudio yet since I'm not familiar with those materials, but this shouldn't be too difficult to add.
This is a work in progress that ties all of these related issues together.

Before I got much further, I wanted to open this up for discussion and feedback.

- Any thoughts on the data set?
- Should we try to handle these issues piece by piece, or does it make sense to address them all at once?