### PR TITLE
fix link to contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All participants should agree to abide by [The Carpentries Code of Conduct](http
 
 ## Authors
 
-The Genomics workshop overview is authored and maintained by the [community](https://github.com/data-lessons/wrangling-genomics/network/members).
+The Genomics workshop overview is authored and maintained by the [community](https://github.com/datacarpentry/genomics-workshop/network/members).
 
 ## Citation
 


### PR DESCRIPTION
Previous link went to the wrangling lesson in data-lessons, which is now archived. 