### PR TITLE
Update setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -286,7 +286,7 @@ $ samtools
 > ## MacOS
 >
 >~~~
->$ conda install bcftools=1.8=h4da6232_3 
+>$ conda install -c bioconda bcftools=1.8=h4da6232_3 
 >~~~
 >{: .bash}
 {: .solution}


### PR DESCRIPTION
Conda install instruction for MacOS (& Linux) missing '-c bioconda' required for successful install of bcftools

Found this when doing Linux local install using conda.
Mark Fernandes
CRUK Cambridge Institute Carpentries Instructor