### PR TITLE
Update AMI-setup.md

### DIFF
--- a/_extras/AMI-setup.md
+++ b/_extras/AMI-setup.md
@@ -38,7 +38,9 @@ Carpentry workshop,
 #### Create an AWS account
 
 1\. Go to Amazon Web Services [https://aws.amazon.com/](https://aws.amazon.com/)
+
 2\. Follow the button to sign up for an account - you will need to agree to Amazon's terms and conditions and provide credit card information.
+
 
 #### Sign into AWS and Launch an Instance
 1\. Sign into the AWS EC2 Dashboard: [https://console.aws.amazon.com/ec2/](https://console.aws.amazon.com/ec2/)


### PR DESCRIPTION
In https://datacarpentry.org/genomics-workshop/AMI-setup/
Two changes may be done
a) Under "Create an AWS account"
List item 1 and 2 are shown in the same sentence instead of separate list items.
b) We may need one line gap between "Create an AWS account" and "Sign into AWS and Launch an Instance"

Proposed:
Create an AWS account
1. Go to Amazon Web Services https://aws.amazon.com/ ----one enter here for separation---
2. Follow the button to sign up for an account - you will need to agree to Amazon’s terms and conditions and provide credit card information.
-------one line gap here-------
Sign into AWS and Launch an Instance
1. Sign into the AWS EC2 Dashboard: https://console.aws.amazon.com/ec2/
2. Click the ‘Launch Instance’ button


Current:
Create an AWS account
1. Go to Amazon Web Services https://aws.amazon.com/  2. Follow the button to sign up for an account - you will need to agree to Amazon’s terms and conditions and provide credit card information.
Sign into AWS and Launch an Instance
1. Sign into the AWS EC2 Dashboard: https://console.aws.amazon.com/ec2/
2. Click the ‘Launch Instance’ button