### PR TITLE
clarify language for shell lesson

### DIFF
--- a/_extras/teaching_demos.md
+++ b/_extras/teaching_demos.md
@@ -12,6 +12,9 @@ No special instructions.
 
 #### [Introduction to the Command Line for Genomics](https://datacarpentry.org/shell-genomics/)
 
+For your teaching demo, you may follow this lesson locally without an AMI instance. Note that this will
+require some changes to paths throughout the lesson.
+
 Use the following shell commands to download and unzip the necessary data files from FigShare.
 
 ```


### PR DESCRIPTION
per an [issue submitted to instructor training repo](https://github.com/carpentries/instructor-training/issues/1121) 

> the [setup instructions](https://datacarpentry.org/genomics-workshop/teaching_demos/index.html) tell you to download and unzip some files as setup. However, the [Working with Files and Directories](https://datacarpentry.org/shell-genomics/03-working-with-files/index.html) episode asks you to look for files in `/usr/bin` and to look at file permissions assuming you are the user `dcuser`, which will give different results depending on the instructor's local setup. Should the setup instructions suggest that you use the AMI instance as for later lessons, so that your results will be consistent with the lesson material, or is this fine for the teaching demo?