### PR TITLE
Add line about installing ssh or terminal emulator for win

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -15,7 +15,7 @@ Machine Image (AMI). Please follow the instructions below to prepare your comput
 
 ## Required additional software
 
-This lesson requires a working spreadsheet program. If you don't have a spreadsheet program already, you can use LibreOffice. It's a free, open source spreadsheet program.
+This lesson requires a working spreadsheet program. If you don't have a spreadsheet program already, you can use LibreOffice. It's a free, open source spreadsheet program.  Directions to install are included for each Windows, Mac OS X, and Linux systems below. For Windows, you will also need to install Git Bash, PuTTY, or the Ubuntu Subsystem.
 
 > ## Windows
 > - Install LibreOffice by going to [the installation page](https://www.libreoffice.org/download/libreoffice-fresh/). The version for Windows should automatically be selected. Click Download Version X.X.X (whichever is the most recent version). You will go to a page that asks about a donation, but you don't need to make one. Your download should begin automatically.  


### PR DESCRIPTION
I was double checking that the required software section included software to ssh since we are teaching with AWS next week.  I noticed that there are directions in the windows section but it is not described in the paragraph above.  This PR adds some text to the paragraph above.