### PR TITLE
Removing Alpha warning

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,8 +9,6 @@ utilities, use of command-line tools to analyze sequence quality and
 perform variant calling, and connecting to and using cloud computing. This workshop is designed to 
 be taught over two full days of instruction.
 
-**Please note that workshop materials for working with Genomics data in R are in “alpha” development. These lessons are available for review and for informal teaching experiences, but are not yet part of The Carpentries’ official lesson offerings.**
-
 Interested in teaching these materials? We have an [onboarding video](https://www.youtube.com/watch?v=zgdutO5tejo) and accompanying [slides](https://docs.google.com/presentation/d/1fLlT2lPv32DqCFpRPPdHZBNHiQTpK79wd5Z3nsFwL3s/edit#slide=id.p) available to prepare Instructors to teach these lessons. After watching this video, please contact team@carpentries.org so that we can record your status as an onboarded Instructor. Instructors who have completed onboarding will be given priority status for teaching at centrally-organized Data Carpentry Genomics workshops.
 
 


### PR DESCRIPTION
The main workshop page still says this lesson is in alpha.  Given how much it has been taught, I think the warning should be removed.

I would suggest also maybe considering updating the 2 days language with common schedules since it would be tough to teach all the lessons in 2 days.