### PR TITLE
fixing line wrapping of common schedules

### DIFF
--- a/index.md
+++ b/index.md
@@ -63,22 +63,22 @@ If you want to run your own instance of the server used for this workshop, follo
 
 ### Schedule A (2 days OR 4 half days)
 
-Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
-Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
-Half-day 3 & 4 : [Data wrangling and processing](https://datacarpentry.github.io/wrangling-genomics/)
+* Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
+* Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued). 
+* Half-day 3 & 4 : [Data wrangling and processing](https://datacarpentry.github.io/wrangling-genomics/)
 
 ### Schedule B (2 days OR 4 half days)
 
-Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
-Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
-Half-day 3 & 4: [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)
+* Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
+* Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
+* Half-day 3 & 4: [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)
 
 ### Schedule C (3 days OR 6 half days)
 
-Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
-Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
-Half-day 3 & 4 : [Data wrangling and processing](https://datacarpentry.github.io/wrangling-genomics/)
-Half-day 5 & 6: [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)
+* Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
+* Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
+* Half-day 3 & 4 : [Data wrangling and processing](https://datacarpentry.github.io/wrangling-genomics/)
+* Half-day 5 & 6: [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)
 
 
 

--- a/index.md
+++ b/index.md
@@ -63,22 +63,22 @@ If you want to run your own instance of the server used for this workshop, follo
 
 ### Schedule A (2 days OR 4 half days)
 
-* Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
-* Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued). 
-* Half-day 3 & 4 : [Data wrangling and processing](https://datacarpentry.github.io/wrangling-genomics/)
+- Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
+- Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued). 
+- Half-day 3 & 4 : [Data wrangling and processing](https://datacarpentry.github.io/wrangling-genomics/)
 
 ### Schedule B (2 days OR 4 half days)
 
-* Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
-* Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
-* Half-day 3 & 4: [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)
+- Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
+- Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
+- Half-day 3 & 4: [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)
 
 ### Schedule C (3 days OR 6 half days)
 
-* Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
-* Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
-* Half-day 3 & 4 : [Data wrangling and processing](https://datacarpentry.github.io/wrangling-genomics/)
-* Half-day 5 & 6: [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)
+- Half-day 1: [Project organization and management](https://datacarpentry.github.io/organization-genomics/) & [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/)
+- Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
+- Half-day 3 & 4 : [Data wrangling and processing](https://datacarpentry.github.io/wrangling-genomics/)
+- Half-day 5 & 6: [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)
 
 
 


### PR DESCRIPTION
Follow-up from #139 as I missed adding the spaces to break lines at the end and it combining them to the same line. I figured bulleted lists would be better but am happy to fix.  Also don't quite remember if * or - is preferred for bulleted lists in the workbench markdown so let me know if that isn't right.