### PR TITLE
Improve accessibility of links in software table

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -146,12 +146,12 @@ More information about these data will be presented in
 
 | Software | Version | Manual | Available for         | Description                                                           | 
 | -------- | ------- | ------ | --------------------- | --------------------------------------------------------------------- |
-| [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)         | 0\.11.9  | [Link](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/)       | Linux, MacOS, Windows | Quality control tool for high throughput sequence data.               | 
-| [Trimmomatic](https://www.usadellab.org/cms/?page=trimmomatic)         | 0\.39    | [Link](https://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/TrimmomaticManual_V0.32.pdf)       | Linux, MacOS, Windows | A flexible read trimming tool for Illumina NGS data.                  | 
-| [BWA](https://bio-bwa.sourceforge.net/)         | 0\.7.17  | [Link](https://bio-bwa.sourceforge.net/bwa.shtml)       | Linux, MacOS          | Mapping DNA sequences against reference genome.                       | 
-| [SAMtools](https://samtools.sourceforge.net/)         | 1\.9     | [Link](https://www.htslib.org/doc/samtools.html)       | Linux, MacOS          | Utilities for manipulating alignments in the SAM format.              | 
-| [BCFtools](https://samtools.github.io/bcftools/)         | 1\.9     | [Link](https://samtools.github.io/bcftools/bcftools.html)       | Linux, MacOS          | Utilities for variant calling and manipulating VCFs and BCFs.         | 
-| [IGV](https://software.broadinstitute.org/software/igv/home)         | [Link](https://software.broadinstitute.org/software/igv/download)        | [Link](https://software.broadinstitute.org/software/igv/UserGuide)       | Linux, MacOS, Windows | Visualization and interactive exploration of large genomics datasets. | 
+| [FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)         | 0\.11.7  | [Documentation](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/)       | Linux, MacOS, Windows | Quality control tool for high throughput sequence data.               | 
+| [Trimmomatic](https://www.usadellab.org/cms/?page=trimmomatic)         | 0\.38    | [Documentation](https://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/TrimmomaticManual_V0.32.pdf)       | Linux, MacOS, Windows | A flexible read trimming tool for Illumina NGS data.                  | 
+| [BWA](https://bio-bwa.sourceforge.net/)         | 0\.7.17  | [Documentation](https://bio-bwa.sourceforge.net/bwa.shtml)       | Linux, MacOS          | Mapping DNA sequences against reference genome.                       | 
+| [SAMtools](https://samtools.sourceforge.net/)         | 1\.9     | [Documentation](https://www.htslib.org/doc/samtools.html)       | Linux, MacOS          | Utilities for manipulating alignments in the SAM format.              | 
+| [BCFtools](https://samtools.github.io/bcftools/)         | 1\.8     | [Documentation](https://samtools.github.io/bcftools/bcftools.html)       | Linux, MacOS          | Utilities for variant calling and manipulating VCFs and BCFs.         | 
+| [IGV](https://software.broadinstitute.org/software/igv/home)         | [Latest](https://software.broadinstitute.org/software/igv/download)        | [Documentation](https://software.broadinstitute.org/software/igv/UserGuide)       | Linux, MacOS, Windows | Visualization and interactive exploration of large genomics datasets. | 
 
 ### QuickStart Software Installation Instructions
 


### PR DESCRIPTION
_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

The link text in the table of software used in the lesson is currently not informative. This commit adjusts the link text to read "Documentation" for links to the docs for each tool, and "Latest" for the link to the IGV download page, as that link appears in the "Version" column.

This should make the table more accessible for people visiting the page with a screen reader.

_If any relevant discussions have taken place elsewhere, please provide links to these._

n/a
