### PR TITLE
Update and clarify genomics-r-intro disclaimer 

### DIFF
--- a/index.md
+++ b/index.md
@@ -58,9 +58,9 @@ More information about this data is available on the [Data page](https://datacar
 
 | Lesson | Overview                                                                                                                                                                      | 
 | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)       | Use R to analyze and visualize between-sample variation.  
+| [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)       | Use R to analyze and visualize between-sample variation.                                                                                                                      | 
 
-**Please note that lesson [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/) is in "beta" development, which means that it is currently being piloted by instructors, but is not yet part of The Carpentries' official lesson offerings.**                                                                                                                    | 
+**Please note that lesson [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/) is in "beta" development, which means that it is currently being piloted by instructors, but is not yet part of The Carpentries' official lesson offerings.**    
 
 # Teaching Platform
 
@@ -88,5 +88,4 @@ If you want to run your own instance of the server used for this workshop, follo
 - Half-day 2: [Introduction to the command line](https://datacarpentry.github.io/shell-genomics/) (continued)
 - Half-day 3 \& 4 : [Data wrangling and processing](https://datacarpentry.github.io/wrangling-genomics/)
 - Half-day 5 \& 6: [Intro to R and RStudio for Genomics](https://datacarpentry.org/genomics-r-intro/)
-
 


### PR DESCRIPTION
**Why this PR is needed**
This `alpha` status disclaimer is confusing to me, I thought it meant all the Genomics Data carpentry material was in `alpha` status. 

Reading through the issues I realised that the disclaimer refers to the `genomics-r-intro` lesson that has now moved from `alpha` to `beta` status (see [genomics-r-intro #207](https://github.com/datacarpentry/genomics-r-intro/issues/207))

**What this PR does**
Updates and clarifies information in the disclaimer, and moves the disclaimer to the `Optional Additional Lessons` section which has mentions the lesson in question.

**Linked issue**
Resolves #137