### PR TITLE
Update info about AWS instances provided by The Carpentries

### DIFF
--- a/instructors/AMI-setup.md
+++ b/instructors/AMI-setup.md
@@ -13,7 +13,7 @@ title: Launching your own AMI instances
 - a Maintainer for one of the Genomics lessons, or
 - contributing to the Genomics lessons
 
-The Carpentries staff can create AMI instances for you. Please contact
+The Carpentries staff will create AMI instances for you. Please contact
 [team@carpentries.org](mailto:team@carpentries.org).
 
 **If you are:** 


### PR DESCRIPTION
**Why this PR is needed**
In February 2025 it was announced that AWS instances provided by The Carpentries for self-organised Data Carpentry Genomics workshops will now have a fee. This change is not reflected in the documentation.

**What this PR does**
Removes self-organised workshops from the list with cases where The Carpentries will provide AWS instances (free of charge).

Clarifies the options people have when self-organizing: setting up instances themselves, or requestion The Carpentries to provide AWS instances (with a reference to the Genomics Policy [here](https://docs.carpentries.org/resources/workshops/genomics_policy.html)).

**Linked issue**
Resolves #164 

